### PR TITLE
RP-1 Lunar Impactor Patch

### DIFF
--- a/Sol-Configs/Patches/Sol-RP1.cfg
+++ b/Sol-Configs/Patches/Sol-RP1.cfg
@@ -1,0 +1,27 @@
+@CONTRACT_TYPE[LunarImpactor]:FINAL
+{
+    @PARAMETER[MoonImpact]
+    {
+        @PARAMETER[LunarImpactorAtMoonLow]
+        {
+            @PARAMETER[ReachMoonSurface]
+            {
+                @maxTerrainAltitude = 8500
+            }
+        }
+    }
+}
+
+@CONTRACT_TYPE[LunarImpactorOptional]:FINAL
+{
+    @PARAMETER[MoonImpact]
+    {
+        @PARAMETER[AtMoonLow]
+        {
+            @PARAMETER[ReachMoonSurface]
+            {
+                @maxTerrainAltitude = 8500
+            }
+        }
+    }
+}


### PR DESCRIPTION
This patch increases the terrain altitude for the two lunar impactor contracts, such that they can be completed with Sol's higher altitude.