### PR TITLE
Fix Principia Quarter Scale Initial Body Positions and Rotations

### DIFF
--- a/Sol-Configs/Patches/Principia/Quarter_Sol-GravityModel.cfg
+++ b/Sol-Configs/Patches/Principia/Quarter_Sol-GravityModel.cfg
@@ -2,37 +2,43 @@
 {
   @body[Sun] {
     @gravitational_parameter = 8294527502.621211 km^3/s^2
+    @reference_angle         = 149.4750000 deg
     @angular_frequency       = 28.3688 deg / d
     @reference_radius        = 174000.0 km
   }
 
   @body[Mercury] {
     @gravitational_parameter = 1376.9862500000013 km^3/s^2
+    @reference_angle         = 33.6638310 deg
     @angular_frequency       = 12.2770216 deg / d
     @reference_radius        = 610.0 km
   }
 
   @body[Venus] {
     @gravitational_parameter = 20303.662000000004 km^3/s^2
+    @reference_angle         = 287.3041118 deg
     @angular_frequency       = -2.9627376 deg / d
     @reference_radius        = 1512750.0 m
   }
 
   @body[Earth] {
     @gravitational_parameter = 24912.527214756 km^3/s^2
+    @reference_angle         = 10.6783215329051 deg
     @angular_frequency       = 721.971247 deg / d
     @reference_radius        = 1594.534075 km
   }
 
   @body[Moon] {
     @gravitational_parameter = 306.42500413523726 km^3/s^2
-    @angular_frequency       = 26.3527163 deg / d
+    @reference_angle         = 61.9182037 deg
+    @angular_frequency       = 26.352731512 deg / d
     @reference_radius        = 434.5 km
   }
 
   // Mars
   @body[Mars] {
     @gravitational_parameter = 2676.773351293693 km^3/s^2
+    @reference_angle         = 65.9410774 deg
     @angular_frequency       = 701.783964887 deg / d
     @reference_radius        = 849.0 km
   }
@@ -40,228 +46,318 @@
   // Phobos
   @body[Phobos] {
     @gravitational_parameter = 4.42971629180903e-05 km^3/s^2
+    @reference_angle         = 333.5668313 deg
     @angular_frequency       = 2257.68951856 deg / d
     @reference_radius        = 2.779951256390520e+00 km
   }
 
-
   // Deimos
   @body[Deimos] {
     @gravitational_parameter = 6.00973103007519e-06 km^3/s^2
+    @reference_angle         = 334.9986146 deg
     @angular_frequency       = 1140.647588 deg / d
     @reference_radius        = 1.567991778785e+00 km
   }
 
   @body[Jupiter] {
     @gravitational_parameter = 7917908.43261255 km^3/s^2
+    @reference_angle         = 263.0109883 deg
     @angular_frequency       = 1741.072 deg / d
     @reference_radius        = 17873.0 km
   }
 
   @body[Io] {
     @gravitational_parameter = 372.4947520881503 km^3/s^2
+    @reference_angle         = 23.8504622 deg
     @angular_frequency       = 406.9779076 deg / d
     @reference_radius        = 4.553306270703300e+02 km
   }
 
   @body[Europa] {
     @gravitational_parameter = 200.17117343268075 km^3/s^2
+    @reference_angle         = 350.246 deg
     @angular_frequency       = 202.749447 deg / d
   }
 
   @body[Ganymede] {
     @gravitational_parameter = 617.989653333384 km^3/s^2
+    @reference_angle         = 243.4301856 deg
     @angular_frequency       = 100.6352162 deg / d
   }
 
   @body[Callisto] {
     @gravitational_parameter = 448.7055850873294 km^3/s^2
+    @reference_angle         = 48.284479 deg
     @angular_frequency       = 43.142143 deg / d
   }
+
   @body[Amalthea]
   {
     @gravitational_parameter = 8.676308030000000e-03 km^3/s^2
+    @reference_angle         = 351.7501912 deg
     @angular_frequency       = 1.445263431082000e+03 deg / d
   }
+
   @body[Thebe]
   {
     @gravitational_parameter = 1.793659833125000e-03 km^3/s^2
+    @reference_angle         = 86.7636969 deg
     @angular_frequency       = 1.067400405612000e+03 deg / d
   }
+
   @body[Saturn] {
     @gravitational_parameter = 2370700.468665765 km^3/s^2
+    @reference_angle         = 243.4301856 deg
     @angular_frequency       = 1621.5878048 deg / d
     @reference_radius        = 15082.5 km
   }
+
   @body[Mimas] {
     @gravitational_parameter = 0.15647025 km^3/s^2
+    @reference_angle         = 136.0478087 deg
     @angular_frequency       = 763.9801305 deg / d
     @reference_radius        = 4.955995938787200e+01 km
   }
+
   @body[Enceladus] {
     @gravitational_parameter = 0.450715885364125 km^3/s^2
+    @reference_angle         = 215.5695638  deg
     @angular_frequency       = 525.4797183 deg / d
     @reference_radius        = 6.301920066999230e+01 km
   }
+
   @body[Tethys] {
     @gravitational_parameter = 2.575692364150625 km^3/s^2
+    @reference_angle         = 226.0430196 deg
     @angular_frequency       = 381.395817 deg / d
     @reference_radius        = 1.327769186854880e+02 km
   }
+
   @body[Dione] {
     @gravitational_parameter = 9.615569648120313e-05 km^3/s^2
+    @reference_angle         = 102.8103240 deg
     @angular_frequency       = 263.0697011 deg / d
     @reference_radius        = 1.404407886878710e+02 km
   }
+
   @body[Rhea] {
     @gravitational_parameter = 9.62140402209375 km^3/s^2
+    @reference_angle         = 167.8953089 deg
     @angular_frequency       = 159.3800956 deg / d
     @reference_radius        = 1.909328260965630e+02 km
   }
+
   @body[Titan] {
     @gravitational_parameter = 561.1336485339375 km^3/s^2
+    @reference_angle         = 338.7574136 deg
     @angular_frequency       = 45.1539536 deg / d
   }
+
   @body[Hyperion] {
     @gravitational_parameter = 2.315489705506250e-02 km^3/s^2
+    @reference_angle         = 155.8929932 deg
     @angular_frequency       = 5.538461538461600e+01 deg / d
     @reference_radius        = 3.406319232143280e+01 km
   }
+
   @body[Iapetus] {
     @gravitational_parameter = 7.53200554395625 km^3/s^2
+    @reference_angle         = 208.1526771 deg
     @angular_frequency       = 9.075620355 deg / d
     @reference_radius        = 1.835818601249050e+02 km
   }
+
   @body[Phoebe]
   {
     @gravitational_parameter = 3.463140007568750e-02 km^3/s^2
+    @reference_angle         = 67.5821605 deg
     @angular_frequency       = 1.863278000000000e+03 deg / d
     @reference_radius        = 2.664209422499370e+01 km
   }
+
   @body[Uranus]
   {
     @gravitational_parameter = 3.62121913144e+05 km^3/s^2
+    @reference_angle         = 91.0490340 deg
     @angular_frequency       = -1002.3201856 deg / d
     @reference_radius        = 6389.75 km
   }
+
   @body[Ariel]
   {
     @gravitational_parameter = 5.216465269856548 km^3/s^2
+    @reference_angle         = 280.0462855 deg
     @angular_frequency       = -285.6713362 deg / d
     @reference_radius        = 1.447244766723130e+02 km
   }
+
   @body[Umbriel]
   {
     @gravitational_parameter = 5.3183363090558675 km^3/s^2
+    @reference_angle         = 211.7234242 deg
     @angular_frequency       = -173.7377846 deg / d
   }
+
   @body[Titania]
   {
     @gravitational_parameter = 14.1839812733828 km^3/s^2
+    @reference_angle         = 150.2304476 deg
     @angular_frequency       = -82.7028632 deg / d
   }
+
   @body[Oberon]
   {
     @gravitational_parameter = 12.832714390847643 km^3/s^2
+    @reference_angle         = 236.5266554 deg
     @angular_frequency       = -53.4789864 deg / d
   }
+
   @body[Miranda]
   {
     @gravitational_parameter = 0.2699698062020062 km^3/s^2
+    @reference_angle         = 21.9990420 deg
     @angular_frequency       = -509.3813784 deg / d
     @reference_radius        = 5.891997433549330e+01 km
   }
+
   @body[Puck]
   {
     @gravitational_parameter = 7.967186700625000e-03 km^3/s^2
+    @reference_angle         = 142.9707600 deg
     @angular_frequency       = -9.445826192040000e+02 deg / d
   }
+
   @body[Neptune]
   {
     @gravitational_parameter = 427193.7189024795 km^3/s^2
+    @reference_angle         = 239.1694092 deg
     @angular_frequency       = 1072.6256984 deg / d
     @reference_radius        = 6306.25 km
   }
+
   @body[Triton] {
     @gravitational_parameter = 89.22488379531462 km^3/s^2
+    @reference_angle         = 161.7506046 deg
     @angular_frequency       = -122.5145274 deg / d
   }
+
   @body[Proteus]
   {
     @gravitational_parameter = 9.698277004687500e-02 km^3/s^2
+    @reference_angle         = 330.33557833 deg
     @angular_frequency       = 6.434536021520000e+02 deg / d
   }
+
   @body[Nereid]
   {
     @gravitational_parameter = 1.489154791687500e-01 km^3/s^2
+    @reference_angle         = 157.2399517 deg
     @angular_frequency       = 1.490426082456440e+03 deg / d
     @reference_radius        = 4.462499862476280e+01 km
   }
+
   @body[Ceres]
   {
     @gravitational_parameter = 3.91431585076 km^3/s^2
-    @angular_frequency = 1904.306527 deg / d
-    @reference_radius = 117.5 km
+    @reference_angle         = 14.8243051 deg
+    @angular_frequency       = 1904.306527 deg / d
+    @reference_radius        = 117.5 km
   }
+
   @body[Pallas]
   {
     @gravitational_parameter = 8.594967642218750e-01 km^3/s^2
-    @angular_frequency = 2211.6072 deg / d
-    @reference_radius = 64.1615625683 km
+    @reference_angle         = 339.6859999 deg
+    @angular_frequency       = 2211.6072 deg / d
+    @reference_radius        = 64.1615625683 km
   }
+
   @body[Vesta]
   {
     @gravitational_parameter = 1.08051531058 km^3/s^2
-    @angular_frequency = 3234.6662558 deg / d
-    @reference_radius = 66.25 km
+    @reference_angle         = 348.3913771 deg
+    @angular_frequency       = 3234.6662558 deg / d
+    @reference_radius        = 66.25 km
   }
+
   @body[Psyche]
   {
     @gravitational_parameter = 9.55228143688e-2 km^3/s^2
-    @angular_frequency = 4118.20781697 deg / d
-    @reference_radius = 27.4840728754 km
+    @reference_angle         = 107.0734027 deg
+    @angular_frequency       = 4118.20781697 deg / d
+    @reference_radius        = 27.4840728754 km
   }
-  // Ida
-  // Dactyl
-  // Eros
-  // Ryugu
+
+  @body[Ida]
+  {
+    @gravitational_parameter = 1.75194681375e-04 km^3/s^2
+    @reference_angle         = 84.8274449 deg
+  }
+
+  @body[Dactyl]
+  {
+    @gravitational_parameter = 1.25139058125e-08 km^3/s^2
+    @reference_angle         = 253.8893797 deg
+  }
+
+  @body[Eros] {
+    @reference_angle         = 269.2236807 deg
+  }
+
+  @body[Ryugu] {
+    @reference_angle         = 20.4392061 deg    
+  }
+
   @body[Pluto]
   {
     @gravitational_parameter = 54.3508636101 km^3/s^2
-    @angular_frequency = 112.725045 deg / d
+    @reference_angle         = 332.3028993 deg
+    @angular_frequency       = 112.725045 deg / d
   }
+
   @body[Charon]
   {
     @gravitational_parameter = 6.61749930376 km^3/s^2
-    @angular_frequency = 112.725045 deg / d
+    @reference_angle         = 152.3067578 deg
+    @angular_frequency       = 112.725045 deg / d
   }
+
   @body[Nix]
   {
     @gravitational_parameter = 1.08453850375e-4 km^3/s^2
-    @angular_frequency = 393.821944078 deg / d
-    @reference_radius = 4.555377110356850e+00 km
+    @reference_angle         = 190.4122150 deg
+    @angular_frequency       = 393.821944078 deg / d
+    @reference_radius        = 4.555377110356850e+00 km
   }
+
   @body[Hydra]
   {
     @gravitational_parameter = 1.25556188319e-4 km^3/s^2
-    @angular_frequency = 1676.05597909 deg / d
-    @reference_radius = 4.527600465318870e+00 km
+    @reference_angle         = 288.0491966 deg
+    @angular_frequency       = 1676.05597909 deg / d
+    @reference_radius        = 4.527600465318870e+00 km
   }
+
   @body[Kerberos]
   {
     @gravitational_parameter = 4.58843213125e-6 km^3/s^2
-    @angular_frequency = 135.310109252 deg / d
-    @reference_radius = 1.399519339706420e+00 km
+    @reference_angle         = 77.4728358 deg
+    @angular_frequency       = 135.310109252 deg / d
+    @reference_radius        = 1.399519339706420e+00 km
   }
+
   @body[Styx]
   {
     @gravitational_parameter = 2.14822049781e-6 km^3/s^2
-    @angular_frequency = 222.696764092 deg / d
-    @reference_radius = 1.276490908609870e+00 km
+    @reference_angle         = 257.6676682 deg
+    @angular_frequency       = 222.696764092 deg / d
+    @reference_radius        = 1.276490908609870e+00 km
   }
+
   @body[Arrokoth]
   {
     @gravitational_parameter = 3.12221950022e-6 km^3/s^2
-    @angular_frequency = 1085.563513 deg / d
+    @reference_angle         = 244.6588782 deg
+    @angular_frequency       = 1085.563513 deg / d
   }
 }

--- a/Sol-Configs/Patches/Principia/Quarter_Sol-InitialState.cfg
+++ b/Sol-Configs/Patches/Principia/Quarter_Sol-InitialState.cfg
@@ -1,4 +1,5 @@
 @principia_initial_state:HAS[@Sol_Configuration:HAS[#SystemScale[Quarter]]]:AFTER[SolSystem] {
+  @solar_system_epoch = JD2433465.000000000
   @body[Sun]
   {
     @x    = 3.270024866382580e+04 km
@@ -364,12 +365,12 @@
   }
   @body[Dactyl]
   {
-    @x    = -9.769823783053930e+07 km
-    @y    = -4.594133103048210e+07 km
-    @z    = -2.203874872547750e+07 km
-    @vx   = 3.680758178403740e+00 km/s
-    @vy   = -7.039924787286960e+00 km/s
-    @vz   = -3.145403057408460e+00 km/s
+    @x    = -9.769823256989360e+07 km
+    @y    = -4.594133207593470e+07 km
+    @z    = -2.203877663031090e+07 km
+    @vx   = 3.681367076191170e+00 km/s
+    @vy   = -7.036556249668700e+00 km/s
+    @vz   = -3.145094153552870e+00 km/s
   }
   @body[Eros]
   {


### PR DESCRIPTION
As mentioned in issue #9, initial body orbits are not accurate (to 1951) and initial rotation states are flipped by 180 degrees, this PR seeks to fix that.
Along with these fixes, some adjustment to Ida and Dactyl's system were done to fix system instability issues that were occuring after modifying the solar system epoch.
A small adjustment to the Moon's rotational speed (angular frequency) was also added, should ensure a higher degree of precision long-term.

### Changes to Orbits / Epoch ###

- Set the **Solar System** epoch back to July 2nd, 1950 (i.e. half a year, i.e. 182.5 days). This was done to make sure the mod runs only one year of simulation given the current scale of orbits.

#### Moon's and Earth's Initial Rotation and Position, Now Fixed ####
<img width="330" height="344" alt="image" src="https://github.com/user-attachments/assets/13606dc9-4e62-44e8-94cf-45d886517448" /> 

#### Jupiter System ####
<img width="444" height="437" alt="image" src="https://github.com/user-attachments/assets/3d77c232-a901-4a82-9f29-692f7cf3213c" />

#### Solar System Model, January 1, 1951 ####
<img width="326" height="318" alt="image" src="https://github.com/user-attachments/assets/3ec4af65-5c87-4a73-abe8-b936506638b9" />

### Changes to Rotations / Reference Angle ###

- Added new reference angle patches/values to all bodies in the Solar System by using the following formulas, rounded to seven digits of precision.

Note: % means modulo/remainder under this context.

#### Time Difference ####

To know the value for this value, all we have to do is substract the reference instant of the body from the **Game Epoch** (Not the Solar System Epoch)

#### For bodies using reference instant JD2451545.000000000 ####

`Reference Angle = (real scale reference angle + (real scale angular frequency - quarter scale angular frequency) * Time Difference ) % 360`

#### For bodies using reference instant JD2433282.500000000 ####

Note: The only thing that changes is the Julian Day number.

`Reference Angle = ( real scale reference angle + ( real scale angular frequency - quarter scale angular frequency ) * Time Difference ) % 360`

#### Example (For the Earth) ####

`( 329.595914 + ( 6.138506084 - 721.971247 ) * -17897.5 ) % 360 = 10.6783215`

#### Results ####

#### Io ####
<img width="677" height="332" alt="image" src="https://github.com/user-attachments/assets/046313b7-2d5e-49bb-972c-d5a46fb93196" />

#### Mimas ####
<img width="726" height="349" alt="image" src="https://github.com/user-attachments/assets/5c828ec4-7001-43e1-b0ca-f8f5c64afb74" />

#### Miranda ####
<img width="480" height="226" alt="image" src="https://github.com/user-attachments/assets/96de20a7-49aa-4226-bc1c-2e129c97785d" />

### Changes to Ida & Dactyl ###

- Both Ida and Dactyl had their gravitational parameters patched into quarter scale and divided by 16 from real scale. Dactyl's orbit was also slightly adjusted to avoid it from getting kicked out of Ida's SOI.

<img width="686" height="332" alt="image" src="https://github.com/user-attachments/assets/c1016847-48f1-432c-8b53-b61ba0856383" />

### Changes to the Moon's Rotation Speed ###

- The Moon had its rotation speed (angular frequency) very slightly adjusted which, according to the formula (real scale freq * 2) should be more precise. Unless done for a specific reason, feel free to revert this change.

<img width="554" height="338" alt="image" src="https://github.com/user-attachments/assets/c323bfee-a410-470e-a9f0-5584bb5e084a" />

<br></br>
## I strongly suggest thoroughly testing all of these changes to check for any inconsistencies and errors before merging, I'm open for feedback \\(@^0^@)/ ##